### PR TITLE
fix: Table text contrast in light mode

### DIFF
--- a/src/styles/table.css
+++ b/src/styles/table.css
@@ -86,7 +86,7 @@ table.list {
     padding: 1em 0;
     margin: -1em 0;
     text-decoration: none;
-    color: #eee;
+    color: light-dark(#333, #eee);
     &:hover {
       text-decoration: underline;
     }


### PR DESCRIPTION
Before:
<img width="521" height="269" alt="Screenshot 2025-09-03 at 10 09 02" src="https://github.com/user-attachments/assets/2dd3c9d2-cd4a-4dda-a8e5-0416f89eb908" />

After:
<img width="521" height="269" alt="Screenshot 2025-09-03 at 10 11 50" src="https://github.com/user-attachments/assets/ee2b08cf-6e70-437c-b53e-91aa5b33eb10" />
